### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/mneiferbag/python-examples/security/code-scanning/1](https://github.com/mneiferbag/python-examples/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow to explicitly limit the permissions granted to the GITHUB_TOKEN. The minimal starting point recommended by CodeQL is `contents: read`, which is sufficient for most CI workflows that only need to check out code and run tests. This block should be added at the root level of the workflow (above `jobs:`) so that it applies to all jobs unless overridden. No changes to the steps or other workflow logic are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
